### PR TITLE
docs: add instruction to install UEFI target

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ Provides crates useful for building TUIs (Terminal User Interfaces) in a [UEFI](
 
 ## Build
 
-Currently requires building using nightly:
+Firstly add the UEFI target to your toolchain:
+
+```console
+$ rustup target add x86_64-unknown-uefi
+```
+
+Then build using nightly:
 
 ```console
 $ cargo +nightly build --target=x86_64-unknown-uefi


### PR DESCRIPTION
Awesome project! Just tried out in QEMU and works like a charm.

I realized the instructions for installing the required Rust target was missing :)
